### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,24 +6,24 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-KEYWORD1    MCP99600
+KEYWORD1	MCP99600
 
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-KEYWORD2    set_alert_limit
-KEYWORD2    set_alert_hys
-KEYWORD2    set_alert_bit
-KEYWORD2    clear_int_flag
-KEYWORD2    set_alert_mode_bit
-KEYWORD2    set_alert_enable
-KEYWORD2    init
-KEYWORD2    set_cold_junc_resolution
-KEYWORD2    set_ADC_meas_resolution
-KEYWORD2    set_burst_mode_samp
-KEYWORD2    set_sensor_mode
-KEYWORD2    check_data_update
+KEYWORD2	set_alert_limit
+KEYWORD2	set_alert_hys
+KEYWORD2	set_alert_bit
+KEYWORD2	clear_int_flag
+KEYWORD2	set_alert_mode_bit
+KEYWORD2	set_alert_enable
+KEYWORD2	init
+KEYWORD2	set_cold_junc_resolution
+KEYWORD2	set_ADC_meas_resolution
+KEYWORD2	set_burst_mode_samp
+KEYWORD2	set_sensor_mode
+KEYWORD2	check_data_update
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords